### PR TITLE
chore: remove deployment name prefix

### DIFF
--- a/PracticalEmailManagement/package.json
+++ b/PracticalEmailManagement/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "./build.sh",
     "push": "cd build && npx clasp push -f",
-    "deploy": "cd build && npx clasp push -f && npx clasp deploy -i \"$(cat ../deploy_id.txt)\" -d \"DEV - $(git log --pretty=format:'%s' -1)\" "
+    "deploy": "cd build && npx clasp push -f && npx clasp deploy -i \"$(cat ../deploy_id.txt)\" -d \"$(git log --pretty=format:'%s' -1)\" "
   },
   "author": "Ansel Robateau",
   "license": "SEE LICENSE IN ../LICENSE",


### PR DESCRIPTION
<img width="250" src="https://media.giphy.com/media/UPNKZuNUo6ZyX9AL7a/giphy.gif">

- [x] Skip CD?
- [x] Skip feature tests against deployed environments 

### Changes

- [ ] Remove deployment name prefix

### Validate

- Look at the script deployment name.  It should no longer have the prefix `DEV -`
